### PR TITLE
Add jemalloc by default(3/5)

### DIFF
--- a/libc/Android.bp
+++ b/libc/Android.bp
@@ -126,7 +126,7 @@ cc_defaults {
         malloc_pattern_fill_contents: {
             cflags: ["-DSCUDO_PATTERN_FILL_CONTENTS"],
         },
-        malloc_not_svelte: {
+        malloc_use_scudo: {
             cflags: ["-DUSE_SCUDO"],
         },
     },
@@ -137,7 +137,7 @@ cc_defaults {
 }
 
 libc_scudo_product_variables = {
-    malloc_not_svelte: {
+    malloc_use_scudo: {
         cflags: ["-DUSE_SCUDO"],
         whole_static_libs: ["libscudo"],
         exclude_static_libs: [
@@ -149,9 +149,6 @@ libc_scudo_product_variables = {
 
 // Defaults for native allocator libs/includes to make it
 // easier to change.
-// To disable scudo for the non-svelte config remove the line:
-//     product_variables: libc_scudo_product_variables,
-// in the cc_defaults below.
 // ========================================================
 cc_defaults {
     name: "libc_native_allocator_defaults",


### PR DESCRIPTION
Jemalloc by default is good because of  : 

1. Reduced Fragmentation: jemalloc employs sophisticated algorithms to allocate memory in a way that minimizes fragmentation. This fragmentation occurs when freed memory becomes scattered in small chunks, making it difficult to allocate larger blocks efficiently. jemalloc's approach helps maintain contiguous memory regions, leading to faster allocation and deallocation operations.

2. jemalloc excels in multi-threaded environments. It utilizes thread-caching mechanisms and per-thread allocation arenas to minimize contention and improve memory access speed for concurrent threads.

3. jemalloc provides valuable debugging features that can aid in troubleshooting memory-related issues within the operating system. These tools can help pinpoint memory leaks, identify memory usage patterns, and diagnose allocation/deallocation problems, leading to a more stable and reliable system.

4. It also make's the device perform well at higer  load's and improve performance. 


You can check other PR regarding this from these Links.  

[Build](https://github.com/DerpFest-AOSP/build/pull/14) (1/5)
[Build_soong](https://github.com/DerpFest-AOSP/build_soong/pull/6) (2/5)
[Bionic](https://github.com/DerpFest-AOSP/bionic/pull/3) (3/5)
[external_jemalloc_new](https://github.com/DerpFest-AOSP/external_jemalloc_new/pull/1) (4/5)
[manifest](https://github.com/DerpFest-AOSP/manifest/pulls/21) (5/5)
[System_core](https://github.com/DerpFest-AOSP/system_core/pull/5) 